### PR TITLE
Create directory tree, re issue:  backup folder #5 

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,16 +16,76 @@ function activate(context) {
     context.subscriptions.push(disposable);
 }
 
+function saveBackupFile(sBakPath, sFileText) {
+    var sFileDir = $$path.dirname(sBakPath);
+    console.log(
+        `/////////// inside saveBackupFile -- before mkdir\n`,
+        `sFileDir:`, sFileDir
+        );
+    console.log(
+        `/////////// inside saveBackupFile -- before mkdir\n`,
+        `!$$fs.existsSync(sFileDir):`, !$$fs.existsSync(sFileDir)
+        );
+    // console.log(
+    //     `/////////// inside saveBackupFile -- before mkdir\n`,
+    //     `!$$fs.stat(sFileDir, (err, stats) => console.log(stats.isDirectory())):`,
+    //     !$$fs.stat(sFileDir, (err, stats) => console.log(`stats.isDirectory(): ${stats.isDirectory()}`))
+    //     );
+    $$fs.stat(sFileDir, (err, stats) => console.log(`stats.isDirectory(): ${stats.isDirectory()}
+    err: ${err}
+    sFileDir: ${sFileDir}`))
+
+    if (!$$fs.existsSync(sFileDir)) {
+        console.log(`dir tree does not exist, trying to create it`);
+        
+        $$fs.mkdirSync(sFileDir, {recursive: true});
+    }
+    console.log(
+        `/////////// inside saveBackupFile -- after if(dir exist)\n`,
+        `sFileDir:`, sFileDir
+        );
+    console.log(
+        `/////////// inside saveBackupFile 2-- \n`,
+        `sFileText:\n`, sFileText, `\n`,
+    );
+    console.log(
+        `/////////// inside saveBackupFile 3-- \n`,
+        `sBakPath:`, sBakPath, `\n`
+    );
+    $$fs.writeFileSync(sBakPath, sFileText);
+}
+
 function flatSave(oConf, sFileText, sFilePath, sBakPath) {
+    console.log(
+        `/////////// inside flatSave 1-- oConf:`, oConf, `\n`,
+    );
+    console.log(
+        `/////////// inside flatSave 2-- \n`,
+        `sFileText:\n`, sFileText, `\n`,
+    );
+    console.log(
+        `/////////// inside flatSave 3-- \n`,
+        `sFilePath:`, sFilePath, `\n`,
+    );
+    console.log(
+        `/////////// inside flatSave 4-- \n`,
+        `sBakPath:`, sBakPath, `\n`
+    );
+
     try {
         var sFileName = $$path.basename(sFilePath);
+        console.log(
+            `/////////// inside flatSave -- try\n`,
+            `sFileName:`, sFileName
+            );
+        
         if (new RegExp(oConf.fileNameMatch).test(sFileName)) {
-            var sFileDir = $$path.dirname(sBakPath);
-            if (!$$fs.existsSync(sFileDir)) {
-                $$fs.mkdirSync(sFileDir);
-            }
-            $$fs.writeFileSync(sBakPath, sFileText); 
+            saveBackupFile(sBakPath, sFileText)
         }
+
+        console.log(`successfully backed up by saveBackup?`);
+        
+        vscode.window.showInformationMessage(`${sFileName} successfully backed up by saveBackup`);
     } catch (error) {
         vscode.window.showErrorMessage(`extension.saveBackup : ${error.message}`);
     }
@@ -34,22 +94,52 @@ function flatSave(oConf, sFileText, sFilePath, sBakPath) {
 function backupFile(document) {
     var sFileText = document.getText();
     var sFilePath = document.uri.path;
-    if (sFilePath[0] === '/') {
-        sFilePath = sFilePath.slice(1); 
-    }
     var oConf = vscode.workspace.getConfiguration('saveBackup.conf');
-
+    console.log(
+            `/////////// inside backupFile -- before if(oConf.enable)\n`,
+            `oConf:`, oConf
+            );
+    console.log(
+            `/////////// inside backupFile -- before if(oConf.enable)\n`,
+            `$$path.basename(sFilePath):`, $$path.basename(sFilePath)
+            );
+    
     if (oConf.enable) {
         var backupDir = getParsePath(oConf.backupDir);
-        var sBakPath = buildeBakPath(sFilePath, backupDir);
+        console.log(
+            `/////////// inside backupFile -- after if(oConf.enable)\n`,
+            `backupDir:`, backupDir
+            );
+        console.log(
+            `/////////// inside backupFile -- after if(oConf.enable)\n`,
+            `$$fs.existsSync(backupDir):`, $$fs.existsSync(backupDir)
+            );
         if ($$fs.existsSync(backupDir)) {
+            var sBakPath
             if (oConf.recreateSubfolders) {
-                //rebuildDirSave()
+                const dirPath = rebuildBakPath(oConf, backupDir, sFilePath);
+                console.log(
+                `/////////// inside backupFile -- recreateSubfolders === true\n`,
+                `dirPath:`, dirPath
+                );
+                const fileName = rebuildFileName(sFilePath, backupDir)
+                console.log(
+                `/////////// inside backupFile -- recreateSubfolders === true\n`,
+                `fileName:`, fileName
+                );
+                sBakPath = $$path.join(dirPath, fileName);
+                console.log(
+                `/////////// inside backupFile -- recreateSubfolders === true\n`,
+                `sBakPath:`, sBakPath
+                );
             } else {
-                var sBakPath = buildeBakPath(sFilePath, backupDir);
-                flatSave(oConf, sFileText, sFilePath, sBakPath)
+                if (sFilePath[0] === '/') {
+                    sFilePath = sFilePath.slice(1); 
+                }
+                sBakPath = buildeBakPath(sFilePath, backupDir);
             }
-        }else{
+            flatSave(oConf, sFileText, sFilePath, sBakPath)
+        } else {
             vscode.window.showErrorMessage(`extension.saveBackup : ${backupDir} does not exist. Create the dir, or configure an existing one in saveBackup.conf.backupDir`);
         }
     }
@@ -66,11 +156,55 @@ function buildeBakPath(sFilePath, sBackupDir) {
 
     return sR;
 }
+
+function rebuildBakPath(oConf, backupDir, sFilePath) {
+    return oConf.recreateFullSubfolders ?
+        $$path.join(backupDir, sFilePath
+            .replace($$path.basename(sFilePath), ''))
+            :
+        $$path.join(backupDir, sFilePath
+            .replace($$path.join(__dirname, '../..'), '')
+            .replace($$path.basename(sFilePath), '')
+            )
+}
+
+function rebuildFileName(sFilePath) {
+    const fN_extension = $$path.extname(sFilePath);
+    const fN_base = $$path.basename(sFilePath, fN_extension)
+    console.log(
+        `/////////// inside backupFile -- after if(oConf.enable)\n`,
+        `fN_extension:`, fN_extension
+        );
+    console.log(
+        `/////////// inside backupFile -- after if(oConf.enable)\n`,
+        `fN_base:`, fN_base
+        );
+
+    var oD = new Date(); 
+    var sTime = `${oD.getFullYear()}${c2(oD.getMonth()+1)}${c2(oD.getDate())}`;
+    sTime += `_${c2(oD.getHours())}${c2(oD.getMinutes())}${c2(oD.getSeconds())}_${(+oD).toString().slice(-3)}`;
+
+    sR = `${fN_base}--${sTime}${fN_extension}`;
+
+    return sR;
+}
+
 function getParsePath(sPath) {
-    var sVscodeDir = $$path.join(__dirname, '../..'); 
+    var sVscodeDir = $$path.join(__dirname, '../..');
+    console.log(
+        `/////////// inside getParsePath -- before replace\n`,
+        `sPath:`, sPath, '\n',
+        `sVscodeDir:`, sVscodeDir,
+        );
     sPath = sPath.replace('${.vscode}', sVscodeDir);
+    console.log(
+        `/////////// inside getParsePath -- after replace\n`,
+        `sPath:`, sPath, '\n',
+        `sPath.replace(/\\/g, '/'):`, sPath.replace(/\\/g, '/'),
+        );
     return sPath.replace(/\\/g, '/');
 }
+
 function c2(n) {
     return (n/100).toFixed(2).slice(-2);
 }

--- a/extension.js
+++ b/extension.js
@@ -16,6 +16,21 @@ function activate(context) {
     context.subscriptions.push(disposable);
 }
 
+function flatSave(oConf, sFileText, sFilePath, sBakPath) {
+    try {
+        var sFileName = $$path.basename(sFilePath);
+        if (new RegExp(oConf.fileNameMatch).test(sFileName)) {
+            var sFileDir = $$path.dirname(sBakPath);
+            if (!$$fs.existsSync(sFileDir)) {
+                $$fs.mkdirSync(sFileDir);
+            }
+            $$fs.writeFileSync(sBakPath, sFileText); 
+        }
+    } catch (error) {
+        vscode.window.showErrorMessage(`extension.saveBackup : ${error.message}`);
+    }
+}
+
 function backupFile(document) {
     var sFileText = document.getText();
     var sFilePath = document.uri.path;
@@ -28,20 +43,14 @@ function backupFile(document) {
         var backupDir = getParsePath(oConf.backupDir);
         var sBakPath = buildeBakPath(sFilePath, backupDir);
         if ($$fs.existsSync(backupDir)) {
-            try {
-                var sFileName = $$path.basename(sFilePath);
-                if (new RegExp(oConf.fileNameMatch).test(sFileName)) {
-                    var sFileDir = $$path.dirname(sBakPath);
-                    if (!$$fs.existsSync(sFileDir)) {
-                        $$fs.mkdirSync(sFileDir);
-                    }
-                    $$fs.writeFileSync(sBakPath, sFileText); 
-                }
-            } catch (error) {
-                vscode.window.showErrorMessage(`extension.saveBackup : ${error.message}`);
+            if (oConf.recreateSubfolders) {
+                //rebuildDirSave()
+            } else {
+                var sBakPath = buildeBakPath(sFilePath, backupDir);
+                flatSave(oConf, sFileText, sFilePath, sBakPath)
             }
         }else{
-            vscode.window.showErrorMessage(`extension.saveBackup : ${backupDir} is not exists. To create the dir, or configure saveBackup.conf.backupDir`);
+            vscode.window.showErrorMessage(`extension.saveBackup : ${backupDir} does not exist. Create the dir, or configure an existing one in saveBackup.conf.backupDir`);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,22 +40,27 @@
             "properties": {
                 "saveBackup.conf.enable": {
                     "type": "boolean",
-                    "description": "Automatically backup into BAK_DIR when save.",
+                    "description": "Automatically backup into 'backupDir' when save.",
                     "default": true
                 },
                 "saveBackup.conf.backupDir": {
                     "type": "string",
-                    "description": "Dir path that backup to.",
+                    "description": "Backup directory path to save to.",
                     "default": "${.vscode}/saveBackup"
                 },
                 "saveBackup.conf.fileNameMatch": {
                     "type": "string",
-                    "description": "Regex for matching files to save enable",
+                    "description": "Regex for choosing which files to backup, if needed",
                     "default": ".*"
                 },
                 "saveBackup.conf.recreateSubfolders": {
                     "type": "boolean",
-                    "description": "Recreate subfolders of the original location, as backupDir/[subFolders]/[fileName-yyyy-mm-dd-hr-mm-ss\n`false` stores all files in backupDir/[fileName]/yyyy-mm-dd-hr-mm-ss",
+                    "description": "Recreate subfolders as in the original file location, i.e. backupDir/[subFolders]/[fileName-yyyy-mm-dd-hr-mm-ss\n`false` stores backed up files in backupDir/[fileName]/yyyy-mm-dd-hr-mm-ss",
+                    "default": true
+                },
+                "saveBackup.conf.recreateFullSubfolders": {
+                    "type": "boolean",
+                    "description": "Recreate the full directory of subfolders inside backupDir/\nFalse: recreate partial subfoder structure. Use false if all your VSCode projects are located inside a common development folder (directories subfolder structure will use the development folder as a root, preventing recreation of home/user/etc for the backup dirs)",
                     "default": false
                 }
             }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com/purplestone/vscode-saveBackup/issues"
     },
     "engines": {
-        "vscode": "^1.14.0"
+        "vscode": "^1.60.2"
     },
     "categories": [
         "Other"
@@ -52,6 +52,11 @@
                     "type": "string",
                     "description": "Regex for matching files to save enable",
                     "default": ".*"
+                },
+                "saveBackup.conf.recreateSubfolders": {
+                    "type": "boolean",
+                    "description": "Recreate subfolders of the original location, as backupDir/[subFolders]/[fileName-yyyy-mm-dd-hr-mm-ss\n`false` stores all files in backupDir/[fileName]/yyyy-mm-dd-hr-mm-ss",
+                    "default": false
                 }
             }
         }


### PR DESCRIPTION
Hi @purplestone, would you consider checking this update to your extension? It should address @lhenry2k [request](https://github.com/purplestone/vscode-saveBackup/issues/5).

In case you were ok with the changes, I could free the code from all the console.logs and update the README.

In essence the update creates two new options for the user:

1. to recreate the directory folders where the original file was in,
2. to choose if the directory tree should be a full or relative path (this second option assumes that the user places his backup folder at the same level than the projects folders, therefore he does not need the full path)

Looking forward to your feedback,
Giampaolo